### PR TITLE
Correcting an issue with detecting arrow functions, has issues with comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,12 +54,13 @@ module.exports = function parseFunction (val) {
   return hiddens(walk(val), orig, val, true)
 }
 
-var SPACE = 32 // ` `
-var GREATER_THAN = 62 // `>`
-var OPEN_PAREN = 40 // `(`
-var CLOSE_PAREN = 41 // `)`
-var OPEN_CURLY = 123 // `{`
-var CLOSE_CURLY = 125 // `}`
+var SPACE = 32           // ` `
+var EQUALS = 61          // `=`
+var GREATER_THAN = 62    // `>`
+var OPEN_PAREN = 40      // `(`
+var CLOSE_PAREN = 41     // `)`
+var OPEN_CURLY = 123     // `{`
+var CLOSE_CURLY = 125    // `}`
 
 /**
  * String walker
@@ -74,13 +75,17 @@ function walk (str) {
   var len = str.length
   var parts = ['']
   var info = {hasParen: false, hasCurly: false, hasArrow: false}
-
+  var nch = ''
+  var ch = '';
   while (i < len) {
     var key = str[i]
-    var ch = key.charCodeAt(0)
-    if (ch === GREATER_THAN) {
-      info.hasArrow = true
-      info.startArrow = info.startArrow || j
+    ch = key.charCodeAt(0)
+    if (ch === EQUALS) {
+      nch = str.charCodeAt(i + 1)
+      if (nch === GREATER_THAN) {
+        info.hasArrow = true
+        info.startArrow = info.startArrow || j
+      }
     }
     if (ch === OPEN_CURLY) {
       info.hasCurly = true

--- a/test.js
+++ b/test.js
@@ -18,11 +18,13 @@ var actuals = {
     'z => {\n  var foo = 1\n  return z * z}',
     '(j, k) => {\n  var foo = 1\n  return j + k}',
     '(a, b) => a * b',
-    'x => x * 2 * x'
+    'x => x * 2 * x',
+    '(results) => {\n  return results.failed > 0;\n}'
   ],
   regulars: [
     'function named (a, b, cb) {\n  var foo = 1\n  cb(null, a * b)\n  }',
-    'function (x, y) {\n  var z = 2\n  return x + y + z)\n  }'
+    'function (x, y) {\n  var z = 2\n  return x + y + z)\n  }',
+    'function (results) {\n  return results.failed > 0;\n}'
   ],
   specials: [
     'function named(a, b, cb) {\n  var foo = 1\n  cb(null, a * b)\n  }',
@@ -60,6 +62,12 @@ var expected = {
     args: ['x'],
     body: 'x * 2 * x',
     value: 'x => x * 2 * x'
+  }, {
+    name: 'anonymous',
+    params: 'results',
+    args: [ 'results' ],
+    body: '\n  return results.failed > 0;\n',
+    value: 'function (results) {\n  return results.failed > 0;\n}'
   }],
   regulars: [{
     name: 'named',
@@ -73,6 +81,12 @@ var expected = {
     args: ['x', 'y'],
     body: '\n  var z = 2\n  return x + y + z)\n  ',
     value: 'function (x, y) {\n  var z = 2\n  return x + y + z)\n  }'
+  }, {
+    name: 'anonymous',
+    params: 'results',
+    args: [ 'results' ],
+    body: '\n  return results.failed > 0;\n',
+    value: 'function (results) {\n  return results.failed > 0;\n}'
   }]
 }
 
@@ -132,4 +146,3 @@ test('should not fails to get .body when something after close curly (issue#3)',
   test.strictEqual(actual.body, 'return a * 2')
   done()
 })
-


### PR DESCRIPTION
Hello, I have corrected an issue with functions containing a greater than operator.

parse-function has still issues with comments containing "=>":

``` js
  function fn (x) {
    // return (x) => 2
    return x > 2;
  }
  console.log(parseFunction(fn));

  // { name: 'fn',
  //   body: '\n    return x > 2;\n  ',
  //   params: 'unction fn(x) {\n    // (x',
  //   args: [ 'unction fn(x) {\n    // (x' ] }

```
