### PR TITLE
fix(): Add support for list of expressions as default value

### DIFF
--- a/src/lib/plugins/params.js
+++ b/src/lib/plugins/params.js
@@ -32,9 +32,23 @@ export default (app) => (node, result) => {
     const name = param.name || defaultArgsName || restArgName
 
     result.args.push(name)
-    result.defaults[name] = param.right
-      ? result.value.slice(param.right.start, param.right.end)
-      : undefined
+
+    if (param.right && param.right.type === 'SequenceExpression') {
+      let value
+      let lastExpression = param.right.expressions.pop()
+
+      if (lastExpression.type === 'NullLiteral') {
+        value = null
+      } else {
+        value = lastExpression.value
+      }
+
+      result.defaults[name] = value
+    } else {
+      result.defaults[name] = param.right
+        ? result.value.slice(param.right.start, param.right.end)
+        : undefined
+    }
   })
   result.params = result.args.join(', ')
 

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,9 @@ const actuals = {
     'function (c) {return c * 3}',
     'function (...restArgs) {return 321}',
     'function () {}',
+    'function (a = (true, false)) {}',
+    'function (a = (true, null)) {}',
+    'function (a, b = (i++, true)) {}',
   ],
   named: [
     'function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3}',
@@ -36,6 +39,9 @@ const actuals = {
     'function namedFn (c) {return c * 3}',
     'function namedFn (...restArgs) {return 321}',
     'function namedFn () {}',
+    'function namedFn(a = (true, false)) {}',
+    'function namedFn(a = (true, null)) {}',
+    'function namedFn(a, b = (i++, true)) {}',
   ],
   generators: [
     'function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3}',
@@ -43,6 +49,9 @@ const actuals = {
     'function * namedFn (c) {return c * 3}',
     'function * namedFn (...restArgs) {return 321}',
     'function * namedFn () {}',
+    'function * namedFn(a = (true, false)) {}',
+    'function * namedFn(a = (true, null)) {}',
+    'function * namedFn(a, b = (i++, true)) {}',
   ],
   arrows: [
     '(a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3}',
@@ -50,6 +59,9 @@ const actuals = {
     '(c) => {return c * 3}',
     '(...restArgs) => {return 321}',
     '() => {}',
+    '(a = (true, false)) => {}',
+    '(a = (true, null)) => {}',
+    '(a, b = (i++, true)) => {}',
     '(a) => a * 3 * a',
     'd => d * 355 * d',
     'e => {return e + 5235 / e}',
@@ -108,6 +120,27 @@ const regulars = [
     args: [],
     body: '',
     defaults: {},
+  },
+  {
+    name: null,
+    params: 'a',
+    args: ['a'],
+    body: '',
+    defaults: {a: false},
+  },
+  {
+    name: null,
+    params: 'a',
+    args: ['a'],
+    body: '',
+    defaults: {a: null},
+  },
+  {
+    name: null,
+    params: 'a, b',
+    args: ['a', 'b'],
+    body: '',
+    defaults: {a: undefined, b: true},
   },
 ]
 


### PR DESCRIPTION
> (a = (doSomething(), doSomethingElse(), true)) => {} is a prefectly valid syntax that is used
> extensively by code instrumenters. When a list of expressions is used as a default value, only the
> last expression is the actual default value. This commit add support for this syntax.
> TAG: latest
> 
> fixes #110

I didn't add a plugin. I think it makes more sense to improve the existing plugin that deals with params since the scope of this change is the params and nothing else.

Tests were added and code coverage preserved.